### PR TITLE
feat: adapt library rows to browser zoom

### DIFF
--- a/UNC.html
+++ b/UNC.html
@@ -19,6 +19,11 @@
             padding: 20px;
         }
 
+        :root {
+            --card-h: 176px;
+            --row-gap: 35px;
+        }
+
         .library-container {
             max-width: 1800px;
             margin: 0 auto;
@@ -92,16 +97,17 @@
         .books-grid {
             display: grid;
             grid-template-columns: repeat(3, 370px);
-            gap: 35px 50px;
+            gap: var(--row-gap) 50px;
             justify-content: center;
         }
 
         .opr-bookself-item {
             width: 370px;
-            height: 176px;
+            height: var(--card-h);
             box-shadow: 0px 3px 6px #e5e7ee;
             padding: 0;
             border-radius: 5px;
+            position: relative;
         }
 
         @media (min-width: 2400px) { 
@@ -274,13 +280,13 @@
 
         .book-index {
             position: absolute;
-            top: -10px;
-            right: -10px;
+            top: 6px;
+            right: 6px;
             background: #047a9c;
             color: white;
             padding: 2px 8px;
             border-radius: 10px;
-            font-size: 10px;
+            font-size: calc(var(--card-h) * 0.06);
             font-weight: 600;
         }
 
@@ -288,7 +294,7 @@
             .book-index {
                 top: 5px;
                 right: 5px;
-                font-size: 12px;
+                font-size: calc(var(--card-h) * 0.08);
             }
         }
     </style>
@@ -1395,6 +1401,56 @@
         let allBooks = [];
         let filteredBooks = [];
 
+        function getZoomPct() {
+            return Math.round(100 / window.devicePixelRatio);
+        }
+
+        function targetRowsFromZoom(zoomPct) {
+            if (zoomPct <= 80) return 4;
+            if (zoomPct <= 110) return 3;
+            if (zoomPct <= 150) return 2;
+            return 1;
+        }
+
+        function updateRowLayout() {
+            const zoomPct = getZoomPct();
+            const targetRows = Math.min(4, Math.max(1, targetRowsFromZoom(zoomPct)));
+
+            const grid = document.getElementById('books-grid');
+            if (!grid) return;
+
+            const headerHeight = grid.getBoundingClientRect().top;
+            const availableHeight = window.innerHeight - headerHeight;
+            const safetyBuffer = 12;
+
+            let cardH = 176;
+            let rowGap = 35;
+            const minGap = 16;
+            const minCard = 120;
+
+            const maxHeight = availableHeight - safetyBuffer;
+            const totalHeight = () => targetRows * cardH + (targetRows - 1) * rowGap;
+
+            while (totalHeight() > maxHeight && rowGap > minGap) {
+                rowGap -= 2;
+            }
+            while (totalHeight() > maxHeight && cardH > minCard) {
+                cardH -= 4;
+            }
+
+            const root = document.documentElement;
+            root.style.setProperty('--card-h', cardH + 'px');
+            root.style.setProperty('--row-gap', rowGap + 'px');
+        }
+
+        function debounce(fn, delay) {
+            let timer;
+            return function () {
+                clearTimeout(timer);
+                timer = setTimeout(fn, delay);
+            };
+        }
+
         function initializeLibrary() {
             allBooks = booksData;
             filteredBooks = [...allBooks];
@@ -1402,6 +1458,7 @@
             updateStats();
             renderBooks();
             setupSearch();
+            updateRowLayout();
         }
 
         function updateStats() {
@@ -1452,6 +1509,7 @@
             `).join('');
 
             grid.innerHTML = booksHTML;
+            updateRowLayout();
         }
 
         function setupSearch() {
@@ -1477,6 +1535,10 @@
             // You can load the corresponding JSON text file: ${index}.json
             // window.open(`texts/${index}.json`, '_blank');
         }
+
+        const updateRowLayoutDebounced = debounce(updateRowLayout, 100);
+        window.addEventListener('resize', updateRowLayoutDebounced);
+        window.addEventListener('orientationchange', updateRowLayoutDebounced);
 
         // Initialize the library when the page loads
         document.addEventListener('DOMContentLoaded', initializeLibrary);


### PR DESCRIPTION
## Summary
- detect browser zoom and map to 1–4 target rows
- scale card height and row spacing to fit rows in viewport
- anchor book index badges inside cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c448d39c1c8331bc7aefa2aef97f03